### PR TITLE
FIX: update bytes returned by node factsign

### DIFF
--- a/operations/factsign.js
+++ b/operations/factsign.js
@@ -70,6 +70,15 @@ export class M2NodeFactSign extends FactSign {
 		this.node = new Address(node);
 	}
 
+	bytes() {
+		return Buffer.concat([
+			this.node.bytes(),
+			this.signer.bytes(),
+			this.sign,
+			this.signedAt.hashBytes(),
+		]);
+	}
+
 	dict() {
 		return {
 			...super.dict(),


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- fix bug

### Current Behavior (Link to an open issue)

- wrong m2 node operation hash

### New Behavior (if this is a feature change)

- wrong node operation hash fixed
- bytes array returned by node fact sign fixed

### Other information

- I recommend to reflect this change to #2.
- close #3 