### PR TITLE
fix: change module export to commonJS style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mitum-sdk",
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"description": "Javascript SDK for mitum",
 	"main": "src/cjs/index.js",
 	"module": "src/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mitum-sdk",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Javascript SDK for mitum",
 	"main": "src/cjs/index.js",
 	"module": "src/esm/index.js",

--- a/src/cjs/alias/currency.js
+++ b/src/cjs/alias/currency.js
@@ -21,7 +21,7 @@ exports.HINT_CURRENCY_REGISTER_OPERATION = "mitum-currency-currency-register-ope
 exports.HINT_CURRENCY_POLICY_UPDATER_OPERATION_FACT = "mitum-currency-currency-policy-updater-operation-fact";
 exports.HINT_CURRENCY_POLICY_UPDATER_OPERATION = "mitum-currency-currency-policy-updater-operation";
 
-// export const HINT_SUFFRAGE_INFLATION_ITEM = "";
+exports.HINT_SUFFRAGE_INFLATION_ITEM = "mitum-currency-suffrage-inflation-item";
 exports.HINT_SUFFRAGE_INFLATION_OPERATION_FACT = "mitum-currency-suffrage-inflation-operation-fact";
 exports.HINT_SUFFRAGE_INFLATION_OPERATION = "mitum-currency-suffrage-inflation-operation";
 

--- a/src/cjs/key/random.js
+++ b/src/cjs/key/random.js
@@ -33,14 +33,14 @@ const randomN = (n, f) => {
     };
 };
 
-export const M1RandomN = (n) => {
+exports.M1RandomN = (n) => {
     return randomN(n, m1.random);
 };
 
-export const M2RandomN = (n) => {
+exports.M2RandomN = (n) => {
     return randomN(n, m2.random);
 };
 
-export const M2EtherRandomN = (n) => {
+exports.M2EtherRandomN = (n) => {
     return randomN(n, m2ether.random);
 };

--- a/src/cjs/operations/currency/suffrage-inflation.js
+++ b/src/cjs/operations/currency/suffrage-inflation.js
@@ -7,6 +7,7 @@ const { MAX_ITEMS_IN_FACT } = require("../../mitum.config.js");
 const {
 	HINT_SUFFRAGE_INFLATION_OPERATION,
 	HINT_SUFFRAGE_INFLATION_OPERATION_FACT,
+	HINT_SUFFRAGE_INFLATION_ITEM,
 } = require("../../alias/currency.js");
 
 const {
@@ -24,7 +25,7 @@ const { sortBuf } = require("../../utils/string.js");
 
 class SuffrageInflationItem extends IBytesDict {
 	constructor(receiver, amount) {
-		super();
+		super(HINT_SUFFRAGE_INFLATION_ITEM);
 		assert(
 			amount instanceof Amount,
 			error.instance(EC_INVALID_AMOUNT, "not Amount instance")

--- a/src/cjs/operations/currency/suffrage-inflation.js
+++ b/src/cjs/operations/currency/suffrage-inflation.js
@@ -18,12 +18,12 @@ const {
 	EC_INVALID_ITEMS,
 	EC_INVALID_FACT,
 } = require("../../base/error.js");
-const { IBytesDict } = require("../../base/interface.js");
+const { Item } = require("../item.js");
 
 const { Address } = require("../../key/address.js");
 const { sortBuf } = require("../../utils/string.js");
 
-class SuffrageInflationItem extends IBytesDict {
+class SuffrageInflationItem extends Item {
 	constructor(receiver, amount) {
 		super(HINT_SUFFRAGE_INFLATION_ITEM);
 		assert(

--- a/src/cjs/operations/currency/suffrage-inflation.js
+++ b/src/cjs/operations/currency/suffrage-inflation.js
@@ -39,6 +39,7 @@ class SuffrageInflationItem extends IBytesDict {
 
 	dict() {
 		return {
+			_hint: this.hint.toString(),
 			receiver: this.receiver.toString(),
 			amount: this.amount.dict(),
 		};

--- a/src/esm/alias/currency.js
+++ b/src/esm/alias/currency.js
@@ -21,7 +21,7 @@ export const HINT_CURRENCY_REGISTER_OPERATION = "mitum-currency-currency-registe
 export const HINT_CURRENCY_POLICY_UPDATER_OPERATION_FACT = "mitum-currency-currency-policy-updater-operation-fact";
 export const HINT_CURRENCY_POLICY_UPDATER_OPERATION = "mitum-currency-currency-policy-updater-operation";
 
-// export const HINT_SUFFRAGE_INFLATION_ITEM = "";
+export const HINT_SUFFRAGE_INFLATION_ITEM = "mitum-currency-suffrage-inflation-item";
 export const HINT_SUFFRAGE_INFLATION_OPERATION_FACT = "mitum-currency-suffrage-inflation-operation-fact";
 export const HINT_SUFFRAGE_INFLATION_OPERATION = "mitum-currency-suffrage-inflation-operation";
 

--- a/src/esm/operations/currency/suffrage-inflation.js
+++ b/src/esm/operations/currency/suffrage-inflation.js
@@ -18,12 +18,12 @@ import {
 	EC_INVALID_ITEMS,
 	EC_INVALID_FACT,
 } from "../../base/error.js";
-import { IBytesDict } from "../../base/interface.js";
+import { Item } from "../item.js";
 
 import { Address } from "../../key/address.js";
 import { sortBuf } from "../../utils/string.js";
 
-export class SuffrageInflationItem extends IBytesDict {
+export class SuffrageInflationItem extends Item {
 	constructor(receiver, amount) {
 		super(HINT_SUFFRAGE_INFLATION_ITEM);
 		assert(

--- a/src/esm/operations/currency/suffrage-inflation.js
+++ b/src/esm/operations/currency/suffrage-inflation.js
@@ -7,6 +7,7 @@ import { MAX_ITEMS_IN_FACT } from "../../mitum.config.js";
 import {
 	HINT_SUFFRAGE_INFLATION_OPERATION,
 	HINT_SUFFRAGE_INFLATION_OPERATION_FACT,
+	HINT_SUFFRAGE_INFLATION_ITEM,
 } from "../../alias/currency.js";
 
 import {
@@ -24,7 +25,7 @@ import { sortBuf } from "../../utils/string.js";
 
 export class SuffrageInflationItem extends IBytesDict {
 	constructor(receiver, amount) {
-		super();
+		super(HINT_SUFFRAGE_INFLATION_ITEM);
 		assert(
 			amount instanceof Amount,
 			error.instance(EC_INVALID_AMOUNT, "not Amount instance")

--- a/src/esm/operations/currency/suffrage-inflation.js
+++ b/src/esm/operations/currency/suffrage-inflation.js
@@ -39,6 +39,7 @@ export class SuffrageInflationItem extends IBytesDict {
 
 	dict() {
 		return {
+			_hint: this.hint.toString(),
 			receiver: this.receiver.toString(),
 			amount: this.amount.dict(),
 		};


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 
-  fix
### Current Behavior (Link to an open issue)
- close #15 
- close #17 
### New Behavior (if this is a feature change)
- The library that supports CommonJS is exporting modules in CommonJS style.